### PR TITLE
Changed `region` parameter to `defaultRegion`

### DIFF
--- a/endpoints/s3.cfc
+++ b/endpoints/s3.cfc
@@ -36,9 +36,9 @@ component accessors="true" implements="commandbox.system.endpoints.IEndpoint" si
 		}
 
 		var aws = new "commandbox.modules.s3-commandbox-commands.aws-cfml.aws" (
-			  awsKey       = credentials.accessKey
-			, awsSecretKey = credentials.secretKey
-			, region       = region
+			  awsKey        = credentials.accessKey
+			, awsSecretKey  = credentials.secretKey
+			, defaultRegion = region
 		);
 
 		var presignedUrl = "//" & aws.s3.generatePresignedURL(


### PR DESCRIPTION
The `region` init argument for aws-cfml/aws.cfc has been changed to `defaultRegion`.